### PR TITLE
Add "Ctrl+Alt+F" tooltip to the format button

### DIFF
--- a/script.js
+++ b/script.js
@@ -188,7 +188,7 @@ const getFormatButtonNew = function () {
     button.style.borderImage = 'none';
     button.style.outline = 'none';
     button.style.cursor = 'pointer';
-    button.title = 'Format';
+    button.title = 'Ctrl + Alt + F';
     button.style.padding = '4px 20px';
     button.style.fontWeight = '600';
     button.style.borderRadius = '3px';
@@ -226,7 +226,7 @@ const getFormatButton = function () {
     button.style.borderImage = 'none';
     button.style.outline = 'none';
     button.style.cursor = 'pointer';
-    button.title = 'Format';
+    button.title = 'Ctrl + Alt + F';
     return button;
 };
 


### PR DESCRIPTION
Before, hovering the "Format" button with the mouse would redundantly display the string "Format", which wasn't helpful. Now, when hovering it with the mouse, it shows a tooltip with the keyboard shortcut "Ctrl+Alt+F" which is more helpful